### PR TITLE
Fix CAN frame handling and ABS state restoration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@
 *.exe
 *.out
 *.app
+
+# Python test cache
+__pycache__/
+*.pyc

--- a/src/abs_dongele_sw_tenere_EURO_4_monochromatic.ino
+++ b/src/abs_dongele_sw_tenere_EURO_4_monochromatic.ino
@@ -18,11 +18,16 @@ const byte absOffMsg[6] = {0x00, 0x01, 0x00, 0x00, 0x00, 0x1C};
 const byte buttonPressMsg[1] = {0x80}; // Button press message
 
 const float delayMs = 4;
+const unsigned long initializationTimeoutMs = 10000;
 
 enum AbsState { ABS_ON, ABS_OFF };
 AbsState currentState = ABS_ON;
 
 byte lastState[6];    // Holds the last state read from EEPROM
+
+bool hasAbsStateByte(byte length) {
+    return length >= sizeof(lastState);
+}
 
 void sendAbsCanMessage(const byte* dataToSend, size_t length) {
     Serial.println("Sending CAN message:");
@@ -94,6 +99,7 @@ void updateEepromIfChanged(const byte* newData, size_t length) {
 
 void setup() {
     Serial.begin(115200);
+    pinMode(CAN_INT_PIN, INPUT);
 
     if (CAN.begin(MCP_ANY, CAN_500KBPS, MCP_8MHZ) == CAN_OK) {
         Serial.println("MCP2515 Initialized Successfully!");
@@ -105,19 +111,26 @@ void setup() {
     CAN.setMode(MCP_NORMAL);
 
     Serial.println("Waiting for ABS initialization...");
-    while (true) {
+    bool stateRestored = false;
+    unsigned long waitStartedAt = millis();
+    while (millis() - waitStartedAt < initializationTimeoutMs) {
         if (!digitalRead(CAN_INT_PIN)) {
             unsigned long rxId;
             byte len = 0;
             byte rxBuf[8];
 
-            if (CAN.readMsgBuf(&rxId, &len, rxBuf) == CAN_OK && rxId == absId && rxBuf[5] == absInit) {
+            if (CAN.readMsgBuf(&rxId, &len, rxBuf) == CAN_OK && rxId == absId && hasAbsStateByte(len) && rxBuf[5] == absInit) {
                 Serial.println("Received initialization message. Restoring state...");
                 delay(1000);
                 restoreLastSavedState();
+                stateRestored = true;
                 break;
             }
         }
+    }
+
+    if (!stateRestored) {
+        Serial.println("ABS initialization timed out. Continuing to listen...");
     }
 
     Serial.println("Setup complete. Listening for CAN messages...");
@@ -130,7 +143,7 @@ void loop() {
         byte rxBuf[8];
 
         if (CAN.readMsgBuf(&rxId, &len, rxBuf) == CAN_OK) {
-            if (rxId == absId) {
+            if (rxId == absId && hasAbsStateByte(len)) {
                 byte requiredByte = rxBuf[5];
                 byte currentByte = lastState[5];
 
@@ -140,13 +153,13 @@ void loop() {
                     restoreLastSavedState();
                 } else if (requiredByte != currentByte && requiredByte != 0x1A) {
                     Serial.println("State change detected. Updating EEPROM...");
-                    updateEepromIfChanged(rxBuf, len);
+                    updateEepromIfChanged(rxBuf, sizeof(lastState));
                     Serial.println(requiredByte, HEX);
                     lastState[5] = requiredByte;
                 } else if (requiredByte == 0x1A) {
                     Serial.println("Received 0x1A. Sending last saved ABS state...");
                     delay(1000);
-                    processAbsStateChange((AbsState)currentByte);
+                    restoreLastSavedState();
                 }
             }
         }

--- a/src/abs_dongle_sw_tenere_EURO_5_lcd.ino
+++ b/src/abs_dongle_sw_tenere_EURO_5_lcd.ino
@@ -11,29 +11,46 @@ const unsigned long canId = 0x226;
 const unsigned long absId = 0x268;    // ABS ECU ID
 const unsigned long absButton = 0x2A0;
 
-const byte absOnMsg[6] PROGMEM = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-const byte rearAbsOffMsg[6] PROGMEM = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
-const byte absOffMsg[6] PROGMEM = {0x00, 0x00, 0x00, 0x00, 0x00, 0x02};
-
 const int eepromAddress = 0;
 const unsigned long messageInterval = 4;
+const unsigned long buttonMessageTimeoutMs = 150;
 const byte dataLength = 7;
+const byte savedDataLength = 6;
+
+const byte absOnMsg[dataLength] PROGMEM = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+const byte rearAbsOffMsg[dataLength] PROGMEM = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00};
+const byte absOffMsg[dataLength] PROGMEM = {0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00};
 
 enum AbsState { ABS_ON, ABS_OFF, REAR_ABS_OFF };
 AbsState currentState = ABS_ON;
 
-byte lastState[6];
-byte canMsg[6];
+byte lastState[savedDataLength];
+byte canMsg[dataLength];
 
 unsigned long buttonLastReceived = 0; // Timestamp of last button message
 int buttonMsgCounter = 0;
 bool buttonMsgSent = false;
 
 byte readSavedData(byte* savedData) {
-    for (int i = 0; i < 6; i++) {
+    for (int i = 0; i < savedDataLength; i++) {
         savedData[i] = EEPROM.read(eepromAddress + i);
     }
     return savedData[5];
+}
+
+bool hasAbsStateByte(byte length) {
+    return length >= savedDataLength;
+}
+
+void resetButtonSequence() {
+    buttonMsgCounter = 0;
+    buttonMsgSent = false;
+}
+
+void expireButtonSequenceIfNeeded() {
+    if (buttonMsgCounter > 0 && millis() - buttonLastReceived > buttonMessageTimeoutMs) {
+        resetButtonSequence();
+    }
 }
 
 void updateEepromIfChanged(const byte* newData, size_t length) {
@@ -59,7 +76,7 @@ void sendAbsCanMessage(const byte* dataToSend, size_t length) {
 
     bool success = false;
     for (int i = 0; i < 25; i++) {
-      if (CAN.sendMsgBuf(canId, 0, dataLength, dataToSend) == CAN_OK) {
+      if (CAN.sendMsgBuf(canId, 0, length, dataToSend) == CAN_OK) {
         success = true;
       }
       delay(messageInterval);
@@ -74,16 +91,16 @@ void sendAbsCanMessage(const byte* dataToSend, size_t length) {
 void processAbsStateChange(AbsState state) {
     switch (state) {
         case ABS_ON:
-            memcpy_P(canMsg, absOnMsg, 6);
+            memcpy_P(canMsg, absOnMsg, dataLength);
             break;
         case REAR_ABS_OFF:
-            memcpy_P(canMsg, rearAbsOffMsg, 6);
+            memcpy_P(canMsg, rearAbsOffMsg, dataLength);
             break;
         case ABS_OFF:
-            memcpy_P(canMsg, absOffMsg, 6);
+            memcpy_P(canMsg, absOffMsg, dataLength);
             break;
     }
-    sendAbsCanMessage(canMsg, 6);
+    sendAbsCanMessage(canMsg, dataLength);
 }
 
 void restoreLastSavedState() {
@@ -102,6 +119,7 @@ void restoreLastSavedState() {
 
 void setup() {
     Serial.begin(115200);
+    pinMode(CAN_INT_PIN, INPUT);
 
     if (CAN.begin(MCP_ANY, CAN_500KBPS, MCP_8MHZ) == CAN_OK) {
         Serial.println("MCP2515 Initialized Successfully!");
@@ -115,13 +133,15 @@ void setup() {
 }
 
 void loop() {
+    expireButtonSequenceIfNeeded();
+
     if (!digitalRead(CAN_INT_PIN)) {
         unsigned long rxId;
         byte len = 0;
         byte rxBuf[8];
 
         if (CAN.readMsgBuf(&rxId, &len, rxBuf) == CAN_OK) {
-            if (rxId == absId) {
+            if (rxId == absId && hasAbsStateByte(len)) {
                 byte requiredByte = rxBuf[5];
                 byte currentByte = lastState[5];
 
@@ -132,14 +152,15 @@ void loop() {
                     restoreLastSavedState();
                 } else if (requiredByte != currentByte && requiredByte != 0x1A) {
                     Serial.println("State has changed, updating EEPROM...");
-                    updateEepromIfChanged(rxBuf, dataLength);
+                    updateEepromIfChanged(rxBuf, sizeof(lastState));
                     Serial.println(requiredByte, HEX);
                     lastState[5] = requiredByte;
                 } else if (requiredByte == 0x1A){
                   delay(1000);
-                  processAbsStateChange((AbsState)currentByte);
+                  restoreLastSavedState();
                 }
-            } else if (rxId == absButton) {
+            } else if (rxId == absButton && len >= 1) {
+                buttonLastReceived = millis();
                 if (rxBuf[0] == 0x80) {
                   buttonMsgCounter++;
                   if (buttonMsgCounter > 50 && !buttonMsgSent) {
@@ -151,8 +172,7 @@ void loop() {
                     processAbsStateChange(REAR_ABS_OFF);
                     buttonMsgSent = true;
                   }
-                  buttonMsgCounter = 0;
-                  buttonMsgSent = false;
+                  resetButtonSequence();
                 }
             }
         }

--- a/src/euro5_mono.ino
+++ b/src/euro5_mono.ino
@@ -18,12 +18,17 @@ const byte absOffMsg[6] = {0x00, 0x01, 0x00, 0x00, 0x00, 0x1C};
 const byte buttonPressMsg[1] = {0x80}; // Button press message
 
 const float delayMs = 4;
+const unsigned long initializationTimeoutMs = 10000;
 
 enum AbsState { ABS_ON, ABS_OFF };
 AbsState currentState = ABS_ON;
 
 byte lastState[6];    // Holds the last state read from EEPROM
 bool stateRestored = false;
+
+bool hasAbsStateByte(byte length) {
+    return length >= sizeof(lastState);
+}
 
 void sendAbsCanMessage(const byte* dataToSend, size_t length) {
     Serial.println("Sending CAN message:");
@@ -49,7 +54,7 @@ void sendAbsCanMessage(const byte* dataToSend, size_t length) {
             byte len = 0;
             byte rxBuf[8];
 
-            if (CAN.readMsgBuf(&rxId, &len, rxBuf) == CAN_OK && rxId == absId && rxBuf[5] == 0x30) {
+            if (CAN.readMsgBuf(&rxId, &len, rxBuf) == CAN_OK && rxId == absId && hasAbsStateByte(len) && rxBuf[5] == 0x30) {
                 Serial.println("Detected ABS message 0x30. Stopping button press messages.");
                 return;
             }
@@ -90,21 +95,6 @@ void restoreLastSavedState() {
     }
 
     processAbsStateChange(currentState);
-    Serial.println("Waiting for initialization message to disappear...");
-    while (true) {
-        if (!digitalRead(CAN_INT_PIN)) {
-            unsigned long rxId;
-            byte len = 0;
-            byte rxBuf[8];
-
-            if (CAN.readMsgBuf(&rxId, &len, rxBuf) == CAN_OK) {
-                if (rxId == absId && rxBuf[5] != absInit) {
-                    Serial.println("Initialization message disappeared. Setup complete.");
-                    break;
-                }
-            }
-        }
-    }
 }
 
 void updateEepromIfChanged(const byte* newData, size_t length) {
@@ -122,6 +112,7 @@ void updateEepromIfChanged(const byte* newData, size_t length) {
 
 void setup() {
     Serial.begin(115200);
+    pinMode(CAN_INT_PIN, INPUT);
 
     if (CAN.begin(MCP_ANY, CAN_500KBPS, MCP_8MHZ) == CAN_OK) {
         Serial.println("MCP2515 Initialized Successfully!");
@@ -133,39 +124,25 @@ void setup() {
     CAN.setMode(MCP_NORMAL);
 
     Serial.println("Waiting for ABS initialization...");
-    bool absInitialized = false;
-    while (!absInitialized) {
+    unsigned long waitStartedAt = millis();
+    while (!stateRestored && millis() - waitStartedAt < initializationTimeoutMs) {
         if (!digitalRead(CAN_INT_PIN)) {
             unsigned long rxId;
             byte len = 0;
             byte rxBuf[8];
 
-            if (CAN.readMsgBuf(&rxId, &len, rxBuf) == CAN_OK && rxId == absId && rxBuf[5] == absInit) {
+            if (CAN.readMsgBuf(&rxId, &len, rxBuf) == CAN_OK && rxId == absId && hasAbsStateByte(len) && rxBuf[5] == absInit) {
                 Serial.println("Received initialization message. Restoring state...");
                 delay(1000);
                 restoreLastSavedState();
-                absInitialized = true;
-                break;
+                stateRestored = true;
             }
         }
     }
 
-    Serial.println("Waiting for initialization message to disappear...");
-    while (true) {
-        if (!digitalRead(CAN_INT_PIN)) {
-            unsigned long rxId;
-            byte len = 0;
-            byte rxBuf[8];
-
-            if (CAN.readMsgBuf(&rxId, &len, rxBuf) == CAN_OK) {
-                if (rxId == absId && rxBuf[5] != absInit) {
-                    Serial.println("Initialization message disappeared. Setup complete.");
-                    break;
-                }
-            }
-        }
+    if (!stateRestored) {
+        Serial.println("ABS initialization timed out. Continuing to listen...");
     }
-    stateRestored = true;
     Serial.println("Listening for CAN messages...");
 }
 
@@ -176,7 +153,7 @@ void loop() {
         byte rxBuf[8];
 
         if (CAN.readMsgBuf(&rxId, &len, rxBuf) == CAN_OK) {
-            if (rxId == absId) {
+            if (rxId == absId && hasAbsStateByte(len)) {
                 byte requiredByte = rxBuf[5];
                 byte currentByte = lastState[5];
 
@@ -187,15 +164,15 @@ void loop() {
                     stateRestored = true;
                 } else if (requiredByte != currentByte && requiredByte != 0x1A && requiredByte != 0x30 && requiredByte != absInit) {
                     Serial.println("State change detected. Updating EEPROM...");
-                    updateEepromIfChanged(rxBuf, len);
+                    updateEepromIfChanged(rxBuf, sizeof(lastState));
                     Serial.println(requiredByte, HEX);
                     lastState[5] = requiredByte;
                     stateRestored = false;
                 } else if (requiredByte == 0x1A) {
                     Serial.println("Received 0x1A. Sending last saved ABS state...");
                     delay(1000);
-                    processAbsStateChange((AbsState)currentByte);
-                    stateRestored = false;
+                    restoreLastSavedState();
+                    stateRestored = true;
                 }
             }
         }

--- a/tests/stubs/ArduinoCompat.h
+++ b/tests/stubs/ArduinoCompat.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstddef>
+#include <cstring>
+
+using byte = unsigned char;
+
+#define PROGMEM
+#define memcpy_P(destination, source, length) std::memcpy(destination, source, length)
+
+const int HEX = 16;
+const int INPUT = 0;
+
+class SerialStub {
+public:
+    void begin(unsigned long) {}
+    void println() {}
+
+    template <typename T>
+    void print(const T&) {}
+
+    template <typename T>
+    void print(const T&, int) {}
+
+    template <typename T>
+    void println(const T&) {}
+
+    template <typename T>
+    void println(const T&, int) {}
+};
+
+static SerialStub Serial;
+
+inline void pinMode(int, int) {}
+inline int digitalRead(int) { return 1; }
+inline unsigned long millis() { return 0; }
+inline void delay(unsigned long) {}

--- a/tests/stubs/EEPROM.h
+++ b/tests/stubs/EEPROM.h
@@ -1,0 +1,9 @@
+#pragma once
+
+class EEPROMStub {
+public:
+    byte read(int) { return 0; }
+    void update(int, byte) {}
+};
+
+static EEPROMStub EEPROM;

--- a/tests/stubs/SPI.h
+++ b/tests/stubs/SPI.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/tests/stubs/mcp_can.h
+++ b/tests/stubs/mcp_can.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#define CAN_OK 0
+#define MCP_ANY 0
+#define CAN_500KBPS 0
+#define MCP_8MHZ 0
+#define MCP_NORMAL 0
+
+class MCP_CAN {
+public:
+    explicit MCP_CAN(int) {}
+    int begin(int, int, int) { return CAN_OK; }
+    void setMode(int) {}
+    int sendMsgBuf(unsigned long, byte, byte, const byte*) { return CAN_OK; }
+    int readMsgBuf(unsigned long*, byte*, byte*) { return CAN_OK; }
+};

--- a/tests/test_sketch_safety.py
+++ b/tests/test_sketch_safety.py
@@ -1,0 +1,113 @@
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+
+EURO4 = (SRC / "abs_dongele_sw_tenere_EURO_4_monochromatic.ino").read_text()
+EURO5_MONO = (SRC / "euro5_mono.ino").read_text()
+EURO5_LCD = (SRC / "abs_dongle_sw_tenere_EURO_5_lcd.ino").read_text()
+SKETCH_PATHS = (
+    SRC / "abs_dongele_sw_tenere_EURO_4_monochromatic.ino",
+    SRC / "euro5_mono.ino",
+    SRC / "abs_dongle_sw_tenere_EURO_5_lcd.ino",
+)
+
+
+class SketchSafetyTests(unittest.TestCase):
+    def test_lcd_payloads_initialize_all_seven_transmitted_bytes(self):
+        self.assertIn("const byte dataLength = 7;", EURO5_LCD)
+        for name in ("absOnMsg", "rearAbsOffMsg", "absOffMsg"):
+            match = re.search(
+                rf"const byte {name}\[dataLength\].*?=\s*\{{([^}}]+)\}};",
+                EURO5_LCD,
+            )
+            self.assertIsNotNone(match, name)
+            self.assertEqual(7, len(match.group(1).split(",")), name)
+        self.assertIn("byte canMsg[dataLength];", EURO5_LCD)
+        self.assertIn("CAN.sendMsgBuf(canId, 0, length, dataToSend)", EURO5_LCD)
+        self.assertIn("memcpy_P(canMsg, absOnMsg, dataLength)", EURO5_LCD)
+        self.assertIn("sendAbsCanMessage(canMsg, dataLength)", EURO5_LCD)
+
+    def test_protocol_bytes_are_not_cast_to_enum_ordinals(self):
+        for sketch in (EURO4, EURO5_MONO, EURO5_LCD):
+            self.assertNotIn("(AbsState)currentByte", sketch)
+
+    def test_abs_frames_are_length_checked_before_state_byte_access(self):
+        self.assertIn(
+            "rxId == absId && hasAbsStateByte(len) && rxBuf[5] == absInit",
+            EURO4,
+        )
+        self.assertIn("if (rxId == absId && hasAbsStateByte(len))", EURO4)
+
+        self.assertIn(
+            "rxId == absId && hasAbsStateByte(len) && rxBuf[5] == 0x30",
+            EURO5_MONO,
+        )
+        self.assertIn(
+            "rxId == absId && hasAbsStateByte(len) && rxBuf[5] == absInit",
+            EURO5_MONO,
+        )
+        self.assertIn("if (rxId == absId && hasAbsStateByte(len))", EURO5_MONO)
+
+        self.assertIn("if (rxId == absId && hasAbsStateByte(len))", EURO5_LCD)
+        self.assertIn("else if (rxId == absButton && len >= 1)", EURO5_LCD)
+
+    def test_mono_startup_wait_is_bounded_and_not_duplicated(self):
+        self.assertIn("initializationTimeoutMs", EURO5_MONO)
+        self.assertNotIn("while (true)", EURO5_MONO)
+        restore_body = EURO5_MONO.split("void restoreLastSavedState()", 1)[1].split(
+            "void updateEepromIfChanged", 1
+        )[0]
+        self.assertNotIn("while (", restore_body)
+
+    def test_euro4_startup_wait_is_bounded(self):
+        self.assertIn("initializationTimeoutMs", EURO4)
+        self.assertNotIn("while (true)", EURO4)
+
+    def test_lcd_button_sequence_expires_after_a_message_gap(self):
+        self.assertIn("buttonMessageTimeoutMs", EURO5_LCD)
+        self.assertRegex(
+            EURO5_LCD,
+            r"millis\(\)\s*-\s*buttonLastReceived\s*>\s*buttonMessageTimeoutMs",
+        )
+
+    def test_only_initialized_saved_state_bytes_are_written(self):
+        for sketch in (EURO4, EURO5_MONO, EURO5_LCD):
+            self.assertIn("updateEepromIfChanged(rxBuf, sizeof(lastState))", sketch)
+
+    def test_can_interrupt_pin_is_configured(self):
+        for sketch in (EURO4, EURO5_MONO, EURO5_LCD):
+            self.assertIn("pinMode(CAN_INT_PIN, INPUT);", sketch)
+
+    def test_sketches_pass_host_cpp_syntax_check(self):
+        compiler = shutil.which("clang++")
+        if compiler is None:
+            self.skipTest("clang++ is not installed")
+
+        for sketch_path in SKETCH_PATHS:
+            result = subprocess.run(
+                [
+                    compiler,
+                    "-std=c++11",
+                    "-fsyntax-only",
+                    "-x",
+                    "c++",
+                    "-include",
+                    str(ROOT / "tests/stubs/ArduinoCompat.h"),
+                    "-I",
+                    str(ROOT / "tests/stubs"),
+                    str(sketch_path),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- restore saved ABS protocol states explicitly after kill-switch/reinitialization events
- initialize all seven bytes transmitted by the Euro 5 TFT sketch
- validate CAN frame lengths before reading state bytes
- limit EEPROM writes to the six persisted state bytes
- bound startup waits and expire interrupted TFT button sequences
- add host-side regression and C++ syntax checks for all three sketches

## Root cause

The persisted ABS state bytes are protocol values such as `0x1D` (TFT full ABS-off) and `0x1C` (monochrome full ABS-off), but the kill-switch path cast them directly to enum ordinals. No switch case matched, so the full ABS-off state was not restored. The TFT code also transmitted a seven-byte frame from six-byte payload buffers, and several receive paths indexed CAN data without first checking the frame length.

## Impact

This repairs the full ABS-off restoration path for Euro 5 TFT and monochrome models, applies the same safe restoration behavior to the Euro 4 sketch, and prevents malformed short frames or missing startup transitions from causing unsafe reads or indefinite waits.

## Validation

- `python3 -m unittest -v tests/test_sketch_safety.py` — 9 tests passed
- host-side `clang++ -fsyntax-only` checks passed for all three sketches through the regression suite
- `git diff --check origin/main...HEAD` passed

Hardware/on-bike verification is still required before this is considered release-ready.

Fixes #11
Fixes #12